### PR TITLE
Enable using environment variables in path-mappings and docker-options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LOAD_PACKAGE_FILES = $(foreach load-file, $(PACKAGE_FILES), $(LOAD_FILE))
 TEST_FILES = $(wildcard test/test*.el)
 LOAD_TEST_FILES := $(foreach load-file, $(TEST_FILES), $(LOAD_FILE))
 
-unix-ci: clean unix-build unix-compile unix-test
+unix-ci: clean unix-build unix-compile unix-lint-test unix-unit-test
 
 unix-build:
 	$(CASK) install
@@ -19,9 +19,12 @@ unix-compile:
 	@$(CASK) $(EMACS) -Q -batch -L . -eval '(setq byte-compile-error-on-warn t)' \
 		-f batch-byte-compile $(PACKAGE_FILES)
 
-unix-test:
+unix-lint-test:
 	$(CASK) exec $(EMACS) -batch -L . $(LOAD_PACKAGE_FILES) \
+		--eval "(setq byte-compile-error-on-warn t)" \
 		--eval "(require 'package-lint)" -f package-lint-batch-and-exit
+
+unix-unit-test:
 	$(CASK) exec $(EMACS) -batch -L . $(LOAD_TEST_FILES) -f ert-run-tests-batch-and-exit
 
 clean:

--- a/lsp-docker+.el
+++ b/lsp-docker+.el
@@ -5,7 +5,7 @@
 ;; Author: Yusuke Kitamura <ymyk6602@gmail.com>
 ;; URL: https://github.com/y-kitamu/emacs-lsp-docker-plus
 ;; Keywords: convenience, language server
-;; Package-Requires: ((emacs "25.1") (dash "2.18.1") (lsp-mode "7.0.1") (lsp-docker "0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.18.1") (lsp-mode "7.0.1") (lsp-docker "0.0"))
 ;; Version: 0.1.0
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lsp-docker+.el
+++ b/lsp-docker+.el
@@ -106,8 +106,7 @@ and not used in this function."
                             lsp-docker+-server-command))
          (message (lsp-docker+-format "Skip registering lsp-docker client. Some args are nil.")))
         (t
-         (let ((lsp-docker+-image-id (format "%s %s" lsp-docker+-docker-options lsp-docker+-image-id)))
-           (lsp-docker+-init-clients
+         (lsp-docker+-init-clients
             :path-mappings lsp-docker+-path-mappings
             :default-docker-image-id lsp-docker+-image-id
             :default-docker-container-name lsp-docker+-container-name
@@ -115,7 +114,7 @@ and not used in this function."
             :client-configs (list
                              (list :server-id lsp-docker+-server-id
                                    :docker-server-id lsp-docker+-docker-server-id
-                                   :server-command lsp-docker+-server-command)))))))
+                                   :server-command lsp-docker+-server-command))))))
 
 (cl-defun lsp-docker+-register-client (&rest rest)
   "Advice function of `lsp-docker-register-client'.
@@ -143,7 +142,8 @@ don't work well with Rust langauge servers."
   (if-let ((client (gethash lsp-docker+-server-id lsp-clients))
            (docker-command (lsp-docker-launch-new-container
                             lsp-docker+-container-name lsp-docker+-path-mappings
-                            lsp-docker+-image-id lsp-docker+-server-command)))
+                            (format "%s %s" lsp-docker+-docker-options lsp-docker+-image-id)
+                            lsp-docker+-server-command)))
       (progn
         (lsp-register-client
          (make-lsp-client
@@ -154,7 +154,8 @@ don't work well with Rust langauge servers."
                             (lambda ()
                               (funcall (or lsp-docker+-server-cmd-fn #'lsp-docker-launch-new-container)
                                        lsp-docker+-container-name lsp-docker+-path-mappings
-                                       lsp-docker+-image-id lsp-docker+-server-command)))
+                                       (format "%s %s" lsp-docker+-docker-options lsp-docker+-image-id)
+                                       lsp-docker+-server-command)))
                            :test? (lambda (&rest _)
                                     (-any? (-lambda ((dir)) (f-ancestor-of? dir (buffer-file-name)))
                                            lsp-docker+-path-mappings)))

--- a/lsp-docker+.el
+++ b/lsp-docker+.el
@@ -140,7 +140,10 @@ don't work well with Rust langauge servers."
   server-id = %s, docker-server-id = %s, server-command = %s"
                    lsp-docker+-container-name lsp-docker+-image-id
                    lsp-docker+-server-id lsp-docker+-docker-server-id lsp-docker+-server-command))
-  (if-let ((client (gethash lsp-docker+-server-id lsp-clients)))
+  (if-let ((client (gethash lsp-docker+-server-id lsp-clients))
+           (docker-command (lsp-docker-launch-new-container
+                            lsp-docker+-container-name lsp-docker+-path-mappings
+                            lsp-docker+-image-id lsp-docker+-server-command)))
       (progn
         (lsp-register-client
          (make-lsp-client
@@ -186,7 +189,8 @@ don't work well with Rust langauge servers."
           :download-in-progress? (lsp--client-download-in-progress? client)
           :buffers (lsp--client-buffers client)))
         (message (lsp-docker+-format "Finish register lsp docker client : server-id = %s"
-                                     lsp-docker+-server-id)))
+                                     lsp-docker+-server-id))
+        (message (lsp-docker+-format "Docker command = %s" docker-command)))
     (user-error (lsp-docker+-format "No such client %s" lsp-docker+-server-id))))
 
 (cl-defun lsp-docker+-init-clients

--- a/samples/rust/.dir-locals.el
+++ b/samples/rust/.dir-locals.el
@@ -1,0 +1,12 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((rust-mode
+  . ((lsp-docker+-server-id . rust-analyzer)
+     (lsp-docker+-docker-server-id . rust-analyzer-lsp-docker)
+     (lsp-docker+-server-command . "rust-analyzer")
+     (lsp-docker+-docker-options . "-u ${USER}")
+     (lsp-docker+-image-id . "rust_language-server")
+     (lsp-docker+-container-name . "rust-lsp-docker")
+     (lsp-docker+-path-mappings
+      . (("${HOME}/work/emacs-lsp-docker-plus/samples/rust" . "/project/"))))))

--- a/samples/rust/Dockerfile
+++ b/samples/rust/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:latest
+
+Label version="1.0" maintainer="Y.Kitamu <ymyk6602@gmail.com>"
+
+# add user
+ARG user
+RUN useradd -ms /bin/bash ${user}
+
+# install dependent libraries
+RUN apt-get update && apt-get upgrade -y && apt-get install git curl gcc -y
+
+# setup rust
+USER ${user}
+SHELL ["/bin/bash", "-c"]
+RUN cd /home/${user} &&\
+    curl https://sh.rustup.rs -sSf > ./rust.sh &&\
+    chmod +x ./rust.sh &&\
+    ./rust.sh -y &&\
+    rm -rf ./rust.sh &&\
+    chmod +x /home/${user}/.cargo/env && source /home/${user}/.cargo/env \
+    rustup update
+ENV PATH /home/${user}/.cargo/bin:$PATH
+
+# setup rust-analyzer
+RUN mkdir /home/${user}/opt
+WORKDIR /home/${user}/opt
+RUN git clone https://github.com/rust-analyzer/rust-analyzer.git &&\
+    cd /home/${user}/opt/rust-analyzer && \
+    rustup update && cargo xtask install --server

--- a/samples/rust/docker-compose.yml
+++ b/samples/rust/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+
+services:
+  rust:
+    hostname: rust_docker
+    image: rust-language-server
+    build:
+      context: .
+      args:
+        user: ${USER}


### PR DESCRIPTION
PR for following changes.
- enable using environment variables in path-mappings and docker-options
- add rust docker sample
- bugfixes